### PR TITLE
README.md typo fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,7 +187,7 @@ For example:
 
     voglio antani, Necchi come se fosse 10
     stuzzica:
-        antani come fosse antani menu 1
+        antani come fosse antani meno 1
     e brematura anche, se antani maggiore di 0
 
 maps to:


### PR DESCRIPTION
the <noun> wants <noun> to be sing. otherwise just omit 'the'
...
