### PR TITLE
Don't assume Italian accented characters are available.

### DIFF
--- a/Monicelli.lpp
+++ b/Monicelli.lpp
@@ -87,7 +87,7 @@ CHAR  [a-zA-Z_]
 ("il"|"lo"|"la"|"l'"|"i"|"gli"|"le"|"un"|"un'"|"una"|"dei"|"delle") {
     return token::ARTICLE;
 }
-("più"|"piu'") {
+"pi"("ù"|"u`") {
     return token::OP_PLUS;
 }
 "meno" {
@@ -141,7 +141,7 @@ CHAR  [a-zA-Z_]
 "e "("b"|"p")"rematura anche, se" {
     return token::LOOP_CONDITION;
 }
-"che cos'"("è"|"e'") {
+"che cos'"("è"|"e`") {
     return token::BRANCH_CONDITION;
 }
 "?" {
@@ -150,7 +150,7 @@ CHAR  [a-zA-Z_]
 "o tarapia tapioco" {
     return token::BRANCH_ELSE;
 }
-"e velocit"("à"|"a'")" di esecuzione" {
+"e velocit"("à"|"a`")" di esecuzione" {
     return token::BRANCH_END;
 }
 ":" {


### PR DESCRIPTION
Unfortunately not everybody out there has either an Italian keyboard or is aware of the Italian keyboard layout.  In an effort to make sure the true spirit of the supercazzola can transcend national boundaries, this patch allows substituting accented vowels with their <vowel>+<quote> variant.
