### PR TITLE
Numbers can be written as strings

### DIFF
--- a/Monicelli.lpp
+++ b/Monicelli.lpp
@@ -90,32 +90,36 @@ CHAR  [a-zA-Z_]
 "voglio" {
     return token::VARDECL;
 }
-"come "("se ")?"fosse" {
+"come "("se ")? {
     BEGIN(numeric);
 }
-"fosse"(" ")+ {
+<numeric>"fosse"(" ")+ {
     return token::ASSIGN;
 }
 ("il"|"lo"|"la"|"l'"|"i"|"gli"|"le"|"un"|"un'"|"una"|"dei"|"delle") {
     return token::ARTICLE;
 }
-"pi"("ù"|"u`") {
+"pi"("ù"|"u`")(" ")+ {
+    BEGIN(numeric);
     return token::OP_PLUS;
 }
-"meno" {
+"meno"(" ")+ {
+    BEGIN(numeric);
     return token::OP_MINUS;
 }
-"per" {
+"per"(" ")+ {
+    BEGIN(numeric);
     return token::OP_TIMES;
 }
-"diviso" {
+"diviso"(" ")+ {
+    BEGIN(numeric);
     return token::OP_DIV;
 }
 "con scappellamento a" {
     BEGIN(shift);
 }
-<shift>"per" {
-    BEGIN(INITIAL);
+<shift>"per"(" ")+ {
+    BEGIN(numeric);
 }
 <shift>"sinistra" {
     return token::OP_SHL;
@@ -255,21 +259,17 @@ CHAR  [a-zA-Z_]
 	return token::STRING_NUMBER;
   }
 
-  "." {
-	BEGIN(INITIAL);
-  }
-
   . {
+	yyless(0);
 	BEGIN(INITIAL);
-	REJECT;
   }
 }
 
-<INITIAL,shift>"\n" {
+<INITIAL,shift,numeric>"\n" {
     location->begin.lines();
 }
 
-<INITIAL,shift>[ \t\f\v\r] {
+<INITIAL,shift,numeric>[ \t\f\v\r] {
 }
 
 {CHAR}({DIGIT}|{CHAR})* {

--- a/Monicelli.lpp
+++ b/Monicelli.lpp
@@ -22,6 +22,7 @@
 #include "Parser.hpp"
 
 #include <string>
+#include <algorithm>
 
 static void meta(const char *);
 
@@ -46,12 +47,14 @@ HEXDIGIT [0-9a-zA-Z]
 CHAR  [a-zA-Z_]
 
 %x shift
+%x numeric
 
 %%
 
 "#"[^\n]* {
     meta(yytext + 1);
 }
+
 
 "bituma"[^\n]* {}
 
@@ -88,6 +91,9 @@ CHAR  [a-zA-Z_]
     return token::VARDECL;
 }
 "come "("se ")?"fosse" {
+    BEGIN(numeric);
+}
+"fosse"(" ")+ {
     return token::ASSIGN;
 }
 ("il"|"lo"|"la"|"l'"|"i"|"gli"|"le"|"un"|"un'"|"una"|"dei"|"delle") {
@@ -182,6 +188,81 @@ CHAR  [a-zA-Z_]
 }
 "o magari" {
     return token::CASE_END;
+}
+
+<numeric>{
+  ("mille"|"duemila"|"quattromila"|"cinquemila"|"seimila"|"settemila"|"ottomila"|"novemila") {
+        std::vector<std::string> v{"", "due", "tre", "quattro", "cinque", "sei", "sette", "otto", "nove"};
+        std::string value(yytext);
+        value.resize(value.size() - 5);
+
+        auto it  = std::find(v.begin(), v.end(), value);
+        int val = std::distance(v.begin(), it) + 1;
+
+        lval->intval = 1000 * val;
+        return token::STRING_NUMBER;
+  }
+
+
+  ("due"|"tre"|"quattro"|"cinque"|"sei"|"sette"|"otto"|"nove")?"cento" {
+	std::vector<std::string> v{"", "due", "tre", "quattro", "cinque", "sei", "sette", "otto", "nove"};
+	std::string value(yytext);
+	
+	value.resize(value.size() - 5);
+
+	auto it  = std::find(v.begin(), v.end(), value);
+	int val = std::distance(v.begin(), it) + 1;
+
+	lval->intval = 100 * val;
+	return token::STRING_NUMBER;
+  }
+
+  ("dieci"|"venti"|"trenta"|"quaranta"|"cinquanta"|"sessanta"|"settanta"|"ottanta"|"novanta") {
+	std::vector<std::string> v{"dieci", "venti", "trenta", "quaranta", "cinquanta", "sessanta", "settanta", "ottanta", "novanta"};
+        std::string value(yytext);
+
+        auto it  = std::find(v.begin(), v.end(), value);
+        int val = std::distance(v.begin(), it) + 1;
+
+        lval->intval = 10 * val;
+	return token::STRING_NUMBER;
+  }
+
+  ("undici"|"dodici"|"tredici"|"quattordici"|"quindici"|"sedici"|"diciassette"|"diciotto"|"diciannove") {
+	std::vector<std::string> v{"undici", "dodici", "tredici", "quattordici", "quindici", "sedici", "diciassette", "diciotto", "diciannove"};
+        std::string value(yytext);
+
+        auto it  = std::find(v.begin(), v.end(), value);
+        int val = std::distance(v.begin(), it) + 11;
+
+        lval->intval = val;
+	return token::STRING_NUMBER;
+  }
+
+  ("uno"|"due"|"tre"|"quattro"|"cinque"|"sei"|"sette"|"otto"|"nove") {
+	std::vector<std::string> v{"uno", "due", "tre", "quattro", "cinque", "sei", "sette", "otto", "nove"};
+        std::string value(yytext);
+
+        auto it  = std::find(v.begin(), v.end(), value);
+        int val = std::distance(v.begin(), it) + 1;
+
+        lval->intval = val;
+	return token::STRING_NUMBER;
+  }
+
+  "zero" {
+	lval->intval = 0;
+	return token::STRING_NUMBER;
+  }
+
+  "." {
+	BEGIN(INITIAL);
+  }
+
+  . {
+	BEGIN(INITIAL);
+	REJECT;
+  }
 }
 
 <INITIAL,shift>"\n" {

--- a/Monicelli.ypp
+++ b/Monicelli.ypp
@@ -63,6 +63,8 @@
 %token FUNDECL PARAMS FUNCALL FUN_END
 %token ABORT
 %token ID NUMBER FLOAT
+%token STRING_NUMBER
+%token DOT
 
 %left OP_LT OP_GT OP_LTE OP_GTE
 %left OP_PLUS OP_MINUS
@@ -111,9 +113,12 @@ static std::stack<FunArgList*> funArgStack;
 }
 
 %type<intval> NUMBER
+%type<intval> STRING_NUMBER
 %type<floatval> FLOAT
 %type<strval> ID
 %type<typeval> TYPENAME fun_return
+
+%right STRING_NUMBER
 
 %type<statementval> statement
 %type<statlistval> branch_body
@@ -134,6 +139,7 @@ static std::stack<FunArgList*> funArgStack;
 %type<semiexpval> semi_expression
 %type<idval> variable
 %type<numericval> numeric
+%type<intval> string_number
 %type<mainval> main
 %type<boolval> pointer
 
@@ -230,7 +236,11 @@ var_init:
     /* epsilon */ { $$ = nullptr; } | ASSIGN expression { $$ = $2; }
 ;
 numeric:
-    NUMBER { $$ = new Integer($1); } | FLOAT { $$ = new Float($1); }
+    string_number DOT { $$ = new Integer($1); } | NUMBER DOT { $$ = new Integer($1); } | FLOAT DOT { $$ = new Float($1); }
+;
+string_number:
+    STRING_NUMBER { $$ = $1; }
+    | STRING_NUMBER string_number { $$ = $1 + $2; }
 ;
 variable:
     ID {

--- a/Monicelli.ypp
+++ b/Monicelli.ypp
@@ -64,7 +64,6 @@
 %token ABORT
 %token ID NUMBER FLOAT
 %token STRING_NUMBER
-%token DOT
 
 %left OP_LT OP_GT OP_LTE OP_GTE
 %left OP_PLUS OP_MINUS
@@ -236,7 +235,7 @@ var_init:
     /* epsilon */ { $$ = nullptr; } | ASSIGN expression { $$ = $2; }
 ;
 numeric:
-    string_number DOT { $$ = new Integer($1); } | NUMBER DOT { $$ = new Integer($1); } | FLOAT DOT { $$ = new Float($1); }
+    string_number { $$ = new Integer($1); } | NUMBER { $$ = new Integer($1); } | FLOAT { $$ = new Float($1); }
 ;
 string_number:
     STRING_NUMBER { $$ = $1; }

--- a/examples/hello-world.mc
+++ b/examples/hello-world.mc
@@ -2,15 +2,15 @@
 # Released under GPLv3
 
 Lei ha clacsonato
-voglio una bucaiola, Necchi come se fosse 0 voglio prematurata, Mascetti come se fosse 72
-prematurata a posterdati voglio antifurto, Mascetti come se fosse 87.
-voglio una cofandina, Mascetti come se fosse prematurata con scappellamento a sinistra per 1.
+voglio una bucaiola, Necchi come se fosse zero voglio prematurata, Mascetti come se fosse settantadue
+prematurata a posterdati voglio antifurto, Mascetti come se fosse ottantasette
+voglio una cofandina, Mascetti come se fosse prematurata con scappellamento a sinistra per uno
 cofandina come fosse cofandina meno 33 brematurata la supercazzola antanizzata con antifurto,
 cofandina o scherziamo? vaffanzum bucaiola! bituma scusi, noi siamo in quattro.
 blinda la supercazzola antanizzata con Alfio Mascetti, tarapia Mascetti o scherziamo?
-voglio vicesindaco, Mascetti come se fosse 101 vicesindaco a posterdati voglio pastene,
-Mascetti come se fosse vicesindaco più 7  pastene a posterdati bituma in un certo senso.
+voglio vicesindaco, Mascetti come se fosse centouno vicesindaco a posterdati voglio pastene,
+Mascetti come se fosse vicesindaco piu` sette pastene a posterdati bituma in un certo senso.
 pastene a posterdati tarapia a posterdati Alfio a posterdati tarapia a posterdati 
-voglio scappellamento, Mascetti come se fosse 114 scappellamento a posterdati
-pastene a posterdati voglio Antani, Mascetti come se fosse pastene meno 8 Antani a posterdati
+voglio scappellamento, Mascetti come se fosse centoquattordici scappellamento a posterdati
+pastene a posterdati voglio Antani, Mascetti come se fosse pastene meno otto Antani a posterdati
 vaffanzum!


### PR DESCRIPTION
I think that in a supercazzola is useful to write number as strings.
This patch add supports for stringified numbers in both variables assignments and shifts. Numbers from `zero` to `novemilanovecentonovantanove` are recognized so far.
I have tried to alter as little as possible the existing lexer and parser, so something could be made better.
For example, the syntax of numbers is not checked for, and a number like `millemilleundicidieci` is mapped to 2021. This could be fixed by using more complex rules in the parser.
Furthermore, the rule to sum up numbers in the parser uses right recursion. This consumes a bit more stack, but it was done since this allows to modify as little as possible the existing grammar, and considering that numbers wont't be so long.

As for the lexer, to avoid reducing the space of possible names, numbers live in a separate starting condition. This means that a sentence like: `voglio mille, Necchi come se fosse mille` is correctly interpreted (first `mille` is the variable name, secon `mille` is recognized as 1000).
Note that this implies that writing later `voglio antani, Necchi come se fosse mille` is not mapped to the previously-declared variable, but this is a design choice.

To avoid clashes with future tokens, whenever a character which is not recognized as a possible string number is found, the lexer falls back to the INITIAL starting condition (the shift starting condition should be perfectly compatible with this behviour).

To allow for the recognition of string numbers, the appropriate starting condition should be explicitly set in the lexer. This means that, e.g., in `mille a posterati`, the string `mille` is not currently mapped to a number.
