### PR TITLE
Added options for input and output files.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ compile:
 	flex Monicelli.lpp
 	$(CXX) \
     -Wall -Wno-deprecated-register -std=c++0x -DYYDEBUG=0 -O2 \
-    Parser.cpp lex.yy.cc Nodes.cpp main.cpp -o mcc
+    Parser.cpp lex.yy.cc Nodes.cpp main.cpp ProgramOptions.cpp -o mcc
 
 patch2:
 	# Bison 2 compatibility patch

--- a/ProgramOptions.cpp
+++ b/ProgramOptions.cpp
@@ -1,0 +1,109 @@
+/*
+ * Monicelli: an esoteric language compiler
+ *
+ * Copyright (C) 2014 Stefano Sanfilippo
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "ProgramOptions.hpp"
+#include <iostream>
+#include <map>
+
+using namespace monicelli;
+
+ProgramOptions &
+ProgramOptions::addOption(std::string const & long_value,
+                          std::string const & short_value,
+                          std::string const & description,
+                          std::string const & key)
+{
+    valid_options.push_back(Option(long_value, short_value, description, key));
+    return *this;
+}
+
+uint32_t
+ProgramOptions::getValueAsInt(std::string const & key) const throw (OptionNotFoundException)
+{
+    for (Option const & opt : (*this)) {
+        if (opt.getKey() == key) {
+            return std::stoi(opt.getRawValue());
+        }
+    }
+
+    throw OptionNotFoundException("Option does not exist.");
+}
+
+std::string const &
+ProgramOptions::getValueAsString(std::string const & key) const throw (OptionNotFoundException)
+{
+    for (Option const & opt : (*this)) {
+        if (opt.getKey() == key) {
+            return opt.getRawValue();
+        }
+    }
+
+    throw OptionNotFoundException("Option does not exist.");
+}
+
+bool
+ProgramOptions::parse(bool stop_on_error)
+{
+    // Generate an index of the options to speed up the parsing
+    std::map<std::string, uint8_t> long_index;
+    std::map<std::string, uint8_t> short_index;
+    uint8_t counter(0);
+
+    for (Option const & opt : (*this)) {
+        long_index [opt.long_value]  = counter;
+        short_index[opt.short_value] = counter;
+
+        counter++;
+    }
+
+    // Basic parsing of arguments to keep things simple and portable.
+    for (int ptr = 1; ptr < argc; ptr++) {
+        std::string parsing(argv[ptr]);
+        bool found_long = (long_index.find(parsing) != long_index.end());
+        bool found_short = (short_index.find(parsing) != short_index.end());
+
+        if (found_long or found_short) {
+            uint8_t & index = found_long? long_index[parsing] : short_index[parsing];
+
+            if (++ptr < argc) {
+                Option & opt = valid_options[index];
+                opt.setValue(argv[ptr]);
+            }
+
+            else if (stop_on_error) {
+                return false;
+            }
+        }
+    }
+
+    return true;
+}
+
+bool
+ProgramOptions::optionParsed(std::string const & key)
+{
+    for (Option const & opt : (*this)) {
+        if (opt.getKey() == key) {
+            return opt.isValid();
+        }
+    }
+
+    // No need to throw an exception here.
+    return false;
+}

--- a/ProgramOptions.hpp
+++ b/ProgramOptions.hpp
@@ -1,0 +1,104 @@
+#ifndef PROGRAMOPTIONS_H
+#define PROGRAMOPTIONS_H
+
+/*
+ * Monicelli: an esoteric language compiler
+ *
+ * Copyright (C) 2014 Stefano Sanfilippo
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <exception>
+#include <stdexcept>
+#include <vector>
+#include <string>
+#include <stdint.h>
+
+namespace monicelli {
+
+class Option {
+
+public:
+    Option(std::string const & long_value,
+           std::string const & short_value,
+           std::string const & description,
+           std::string const & key) :
+        long_value(long_value),
+        short_value(short_value),
+        description(description),
+        key(key) {};
+
+public:
+    void setValue(std::string const & value) { this->value = value; }
+    std::string const & getRawValue() const { return value;  }
+    std::string const & getKey() const { return key ; }
+
+    // We can safely assume an option has been parsed if its value is
+    // meaningful (i.e., not empty)
+    bool                isValid() const { return not value.empty(); }
+
+public:
+    std::string long_value;
+    std::string short_value;
+    std::string description;
+
+private:
+    std::string key;
+    std::string value;
+};
+
+class OptionNotFoundException : public std::runtime_error {
+public:
+    OptionNotFoundException(std::string const & error) : std::runtime_error(error) {};
+};
+
+class ProgramOptions {
+
+public:
+    typedef std::vector<Option>        options;
+    typedef options::value_type        value_type;
+    typedef options::const_iterator    const_iterator;
+    typedef options::reverse_iterator  reverse_iterator;
+
+public:
+    ProgramOptions(int argc, char **argv) : argc(argc), argv(argv) {};
+    const_iterator begin() const { return valid_options.begin(); }
+    const_iterator end() const { return valid_options.end(); }
+
+public:
+    // Adds an option to the map of valid ones.
+    ProgramOptions & addOption(std::string const & long_value,
+                               std::string const & short_value,
+                               std::string const & description,
+                               std::string const & key);
+
+    uint32_t            getValueAsInt(std::string const & key) const throw (OptionNotFoundException);
+    std::string const & getValueAsString(std::string const & key) const throw (OptionNotFoundException);
+
+    // Returns true if an option has been parsed successfully
+    bool        optionParsed(std::string const & key);
+
+    bool parse(bool stop_on_error = true);
+
+private:
+    int         argc;
+    char **     argv;
+    options     valid_options;
+};
+
+} // namespace
+
+#endif
+

--- a/main.cpp
+++ b/main.cpp
@@ -19,6 +19,7 @@
 
 #include "Scanner.hpp"
 #include "Parser.hpp"
+#include "ProgramOptions.hpp"
 
 #include <iostream>
 #include <fstream>
@@ -27,7 +28,30 @@ using namespace monicelli;
 
 int main(int argc, char **argv) {
     Program program;
-    Scanner scanner(std::cin);
+    ProgramOptions programOptions(argc, argv);
+
+    std::ifstream input("/dev/stdin");
+    std::ofstream output("/dev/stdout");
+
+    // Chain everything and parse.
+    programOptions.
+        addOption("--input", "-i", "Input file", "input").
+        addOption("--output", "-o", "Output file", "output").
+        parse();
+
+    if (programOptions.optionParsed("input")) {
+        std::string inputString = programOptions.getValueAsString("input");
+        if (inputString != "-")
+            input = std::ifstream(inputString);
+    }
+
+    if (programOptions.optionParsed("output")) {
+        std::string outputString = programOptions.getValueAsString("output");
+        if (outputString != "-")
+            output = std::ofstream(outputString);
+    }
+
+    Scanner scanner(dynamic_cast<std::istream &>(input));
     Parser parser(scanner, program);
 
 #if YYDEBUG
@@ -35,7 +59,7 @@ int main(int argc, char **argv) {
 #endif
 
     parser.parse();
-    program.emit(std::cout);
+    program.emit(dynamic_cast<std::ostream &>(output));
 
     return 0;
 }


### PR DESCRIPTION
Hello,
in order to have mcc feel like a real compiler, some program options have to be parsed.
I've added a facility to do it, in a simple and portable way (among UNIX systems, not sure about Windows though) and started testing using the "-i" and "-o" flags.
Everything is working fine so far.
### Both input and output provided

```
# massi at napi.home in ~/developer/monicelli on git:feature/options x [18:38:57]
$ ./mcc -i examples/float.mc -o float.cpp
META: Test all possible numerical forms (integer and float)

# massi at napi.home in ~/developer/monicelli on git:feature/options x [18:41:40]
$ cat float.cpp 
#include <iostream>
#include <cassert>
#include <cstdlib>

int main() {
    std::cout << (2) << std::endl;
    std::cout << (-2) << std::endl;
    std::cout << (2) << std::endl;
    std::cout << (0.232) << std::endl;
    std::cout << (-2) << std::endl;
    std::cout << (-0.2233) << std::endl;
    std::cout << (2) << std::endl;
    std::cout << (2.233e-23) << std::endl;
}
```
### Only input (output on stdout by default)

```
# massi at napi.home in ~/developer/monicelli on git:feature/options x [18:41:43]
$ ./mcc -i examples/float.mc             
META: Test all possible numerical forms (integer and float)
#include <iostream>
#include <cassert>
#include <cstdlib>

int main() {
    std::cout << (2) << std::endl;
    std::cout << (-2) << std::endl;
    std::cout << (2) << std::endl;
    std::cout << (0.232) << std::endl;
    std::cout << (-2) << std::endl;
    std::cout << (-0.2233) << std::endl;
    std::cout << (2) << std::endl;
    std::cout << (2.233e-23) << std::endl;
}
```
### Only output (input on stdin by default)

```
# massi at napi.home in ~/developer/monicelli on git:feature/options x [18:43:13]
$ cat examples/float.mc| ./mcc -o float.cpp
META: Test all possible numerical forms (integer and float)

# massi at napi.home in ~/developer/monicelli on git:feature/options x [18:43:15]
$ cat float.cpp 
#include <iostream>
#include <cassert>
#include <cstdlib>

int main() {
    std::cout << (2) << std::endl;
    std::cout << (-2) << std::endl;
    std::cout << (2) << std::endl;
    std::cout << (0.232) << std::endl;
    std::cout << (-2) << std::endl;
    std::cout << (-0.2233) << std::endl;
    std::cout << (2) << std::endl;
    std::cout << (2.233e-23) << std::endl;
}
```

Let me know if something feels weird (the parsing might be a little bit _too_ basic?).
Adding a `--help` option should be easy enough, just by tweaking the Option class in order to accept a boolean value and pretty printing the descriptions of all the options.
