### PR TITLE
Same correction as previous pull from "brematurata" to "prematurata" for all other examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -410,4 +410,3 @@ The following phrases are currently reserved with no assigned usage. They cannot
 * `conte`
 * `scusi noi siamo in`
 * `con rinforzino`
-* `conte`

--- a/examples/factorial.mcc
+++ b/examples/factorial.mcc
@@ -8,7 +8,7 @@ Sassaroli o scherziamo?
 
     che cos'è la pazienza?
     1: il gruppo come fosse 2 con scappellamento a destra per 1
-    o tarapia tapioco: il gruppo come fosse brematurata la supercazzola
+    o tarapia tapioco: il gruppo come fosse prematurata la supercazzola
     antanizzata con pazienza meno 1 o scherziamo? per la pazienza
 
     e velocità di esecuzione bitumata! in fretta, e
@@ -22,5 +22,5 @@ Lei ha clacsonato
   mi porga il numero bitumando il vicesindaco, dico, bitumando
   il vicesindaco come fosse un numero
 
-  brematurata la supercazzola antanizzata con il vicesindaco
+  prematurata la supercazzola antanizzata con il vicesindaco
   o scherziamo? a posterdati bitumati, pure, o in questura?

--- a/examples/hello-world.mc
+++ b/examples/hello-world.mc
@@ -5,7 +5,7 @@ Lei ha clacsonato
 voglio una bucaiola, Necchi come se fosse 0 voglio prematurata, Mascetti come se fosse 72
 prematurata a posterdati voglio antifurto, Mascetti come se fosse 87.
 voglio una cofandina, Mascetti come se fosse prematurata con scappellamento a sinistra per 1.
-cofandina come fosse cofandina meno 33 brematurata la supercazzola antanizzata con antifurto,
+cofandina come fosse cofandina meno 33 prematurata la supercazzola antanizzata con antifurto,
 cofandina o scherziamo? vaffanzum bucaiola! bituma scusi, noi siamo in quattro.
 blinda la supercazzola antanizzata con Alfio Mascetti, tarapia Mascetti o scherziamo?
 voglio vicesindaco, Mascetti come se fosse 101 vicesindaco a posterdati voglio pastene,

--- a/examples/primes.beauty.mc
+++ b/examples/primes.beauty.mc
@@ -13,7 +13,7 @@ Lei ha clacsonato
                 controllo come se fosse 0
             e velocità di esecuzione
             amico come se fosse amico più uno
-        e brematura anche, se amico minore di antani
+        e prematura anche, se amico minore di antani
         che cos'è il controllo? uno: 
             antani a posterdati 
         e velocità di esecuzione

--- a/examples/primes.beauty.mc
+++ b/examples/primes.beauty.mc
@@ -17,4 +17,4 @@ Lei ha clacsonato
         che cos'è il controllo? uno: 
             antani a posterdati 
         e velocità di esecuzione
-    e brematura anche, se antani minore del massimo
+    e prematura anche, se antani minore del massimo

--- a/examples/primes.mc
+++ b/examples/primes.mc
@@ -6,6 +6,6 @@ stuzzica antani come se fosse antani più uno, voglio l'amico, Necchi
 come se fosse 2 voglio un controllo, Melandri come se fosse uno stuzzica
 voglio vicino, Necchi come se fosse antani diviso l'amico per un amico,
 che cos'è antani? vicino: controllo come se fosse 0 e velocità di esecuzione,
-amico come se fosse amico più uno e brematura anche, se amico minore di antani,
+amico come se fosse amico più uno e prematura anche, se amico minore di antani,
 che cos'è il controllo? uno: antani a posterdati e velocità di esecuzione
-e brematura anche, se antani minore del massimo
+e prematura anche, se antani minore del massimo

--- a/examples/syntax.beauty.mc
+++ b/examples/syntax.beauty.mc
@@ -12,7 +12,7 @@ Lei ha clacsonato
 
     stuzzica
         il dito come fosse antani
-    e brematura anche, se vicesindaco maggiore di antani
+    e prematura anche, se vicesindaco maggiore di antani
 
     vicesindaco come se fosse antani con scappellamento a destra per 2
 

--- a/examples/syntax.beauty.mc
+++ b/examples/syntax.beauty.mc
@@ -32,7 +32,7 @@ Lei ha clacsonato
     vicesindaco a posterdati
     mi porga il vicesindaco,
 
-    brematurata la supercazzola tombale con alfio, serio o scherziamo?
+    prematurata la supercazzola tombale con alfio, serio o scherziamo?
 
     avvertite don ulrico,
     ho visto la signora!

--- a/examples/syntax.beauty.mc
+++ b/examples/syntax.beauty.mc
@@ -37,7 +37,7 @@ Lei ha clacsonato
     avvertite don ulrico,
     ho visto la signora!
 
-    vicesindaco come se fosse brematurata la supercazzola avanti con il vicesindaco o scherziamo,
+    vicesindaco come se fosse prematurata la supercazzola avanti con il vicesindaco o scherziamo,
     vaffanzum 0!
 
 blinda la supercazzola Necchi antanizzata con alfio Mascetti, barilotto Necchi o scherziamo?

--- a/examples/syntax.mc
+++ b/examples/syntax.mc
@@ -1,13 +1,13 @@
 bituma per caso una piccola prova?
 Lei ha clacsonato voglio il dito, conte Mascetti, voglio antani, Necchi 
 come fosse 2, voglio troppo, Melandri, stuzzica il dito come fosse antani 
-e brematura anche, se vicesindaco maggiore di antani vicesindaco come se fosse 
+e prematura anche, se vicesindaco maggiore di antani vicesindaco come se fosse 
 antani con scappellamento a destra per 2, che cos'è il genio? fantasia: 
 vicesindaco come fosse vicesindaco per antani, o magari intuizione: 
 mi porga il cappellano, zingarata come fosse cappellano più uno, zingarata 
 a posterdati, o magari maggiore di mobiletto: genio a posterdati, 
 o tarapia tapioco: mi porga il cappello e velocità di esecuzione,
-vicesindaco a posterdati, mi porga il vicesindaco, brematurata la supercazzola 
+vicesindaco a posterdati, mi porga il vicesindaco, prematurata la supercazzola 
 tombale con alfio, serio o scherziamo? avvertite don ulrico, ho visto la signora! 
 vicesindaco come se fosse brematurata la supercazzola avanti con il vicesindaco
 o scherziamo, vaffanzum 0! blinda la supercazzola Necchi antanizzata con alfio 


### PR DESCRIPTION
This to have an homogeneous feature in example with the new "supercazzola" instad of old "supercazzora"
