### PR TITLE
Vagrant support

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,7 @@
+VAGRANTFILE_API_VERSION = "2"
+
+Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
+  config.vm.box = "ubuntu/trusty64"
+  config.vm.provision "shell", path: "vagrant/setup.sh"
+  config.vm.synced_folder ".", "/opt/monicelli", owner: "vagrant", group: "vagrant"
+end

--- a/src/BitcodeEmitter.cpp
+++ b/src/BitcodeEmitter.cpp
@@ -38,6 +38,7 @@
 #include <unordered_set>
 #include <initializer_list>
 #include <unordered_map>
+#include <iostream>
 
 // Yes, that's right, no ending ;
 #define GUARDED(call) if (!(call)) return false

--- a/src/BitcodeEmitter.cpp
+++ b/src/BitcodeEmitter.cpp
@@ -39,7 +39,6 @@
 #include <unordered_set>
 #include <initializer_list>
 #include <unordered_map>
-#include <iostream>
 
 // Yes, that's right, no ending ;
 #define GUARDED(call) if (!(call)) return false

--- a/vagrant/setup.sh
+++ b/vagrant/setup.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+echo "deb http://llvm.org/apt/trusty/ llvm-toolchain-trusty-3.5 main" > /etc/apt/sources.list.d/llvm.org.list
+echo "deb-src http://llvm.org/apt/trusty/ llvm-toolchain-trusty-3.5 main" >> /etc/apt/sources.list.d/llvm.org.list
+
+wget -O - http://llvm.org/apt/llvm-snapshot.gpg.key|sudo apt-key add -
+
+apt-get update
+
+apt-get install -y --force-yes llvm-3.5-dev
+
+apt-get install -y bison flex libboost-all-dev libyaml-cpp-dev g++ cmake libedit-dev
+
+ln -s /usr/share /usr/lib/llvm-3.5/share
+ln -s /usr/share/llvm-3.5 /usr/share/llvm
+
+mkdir /opt/monicelli/build
+cd /opt/monicelli/build
+
+cmake ..
+
+make install


### PR DESCRIPTION
To prevent problems with installation and compilation (on Mac OS X and Windows, for example), I added a simple vagrant configuration that compile mcc and mcrt in a clean ubuntu virtual machine. The provisioning script provides all required libraries.

"Only" Virtualbox and Vagrant required :)

Instructions to compile with vagrant:

```
~$ cd [monicelli folder path]
~$ vagrant up  # to start, configure virtual machine and compile monicelli - only first execution requires internet connection and a few minutes to complete
[...]
~$ vagrant ssh  # to enter virtual machine
[...]
vagrant[...]$ cd /opt/monicelli/examples
vagrant[...]$ mcc mandelbrot.mc
vagrant[...]$ llc-3.5 mandelbrot.bc
vagrant[...]$ cc mandelbrot.s /usr/local/lib/libmcrt.a -o mandelbrot
vagrant[...]$ ./mandelbrot  # ENJOY
[...]
vagrant[...]$ exit  # to exit virtual machine
[...]
~$ vagrant halt  # to halt virtual machine
```
